### PR TITLE
Add Omega methods for compatibility with S4MP

### DIFF
--- a/Scripts/sims4communitylib/utils/common_omega_utils.py
+++ b/Scripts/sims4communitylib/utils/common_omega_utils.py
@@ -1,0 +1,32 @@
+from distributor.ops import Op
+from protocolbuffers.Consts_pb2 import MGR_UNMANAGED, MSG_OBJECTS_VIEW_UPDATE
+from protocolbuffers.DistributorOps_pb2 import Operation
+from protocolbuffers.Distributor_pb2 import ViewUpdate
+from server.client import Client
+from sims4communitylib.utils.misc.common_game_client_utils import CommonGameClientUtils
+
+
+class CommonOmegaUtils:
+    """ Utilities for sending messages to the client via the Omega channel. (Improved S4MP compatibility)
+
+    Messages sent through this channel don't replicate to the rest of the clients in a multiplayer S4MP session.
+    """
+
+    @classmethod
+    def send_view_update_message(cls, op: Op, manager_id=MGR_UNMANAGED, object_id=0, client: Client = None):
+        import omega
+        if client is None:
+            client = CommonGameClientUtils.get_first_game_client()
+
+        view_update = ViewUpdate()
+        op_entry = view_update.entries.add()
+
+        op_entry.primary_channel.id.manager_id = manager_id
+        op_entry.primary_channel.id.object_id = object_id
+
+        proto_buff = Operation()
+
+        op.write(proto_buff)
+
+        op_entry.operation_list.operations.append(proto_buff)
+        omega.send(client.id, MSG_OBJECTS_VIEW_UPDATE, view_update.SerializeToString())

--- a/Scripts/sims4communitylib/utils/misc/common_camera_utils.py
+++ b/Scripts/sims4communitylib/utils/misc/common_camera_utils.py
@@ -7,6 +7,7 @@ Copyright (c) COLONOLNUTTY
 """
 from typing import Union
 
+from distributor.ops import FocusCamera, CancelFocusCamera
 from objects.game_object import GameObject
 from server.client import Client
 from sims.sim_info import SimInfo
@@ -15,6 +16,7 @@ from sims4communitylib.modinfo import ModInfo
 from sims4communitylib.services.commands.common_console_command import CommonConsoleCommand, \
     CommonConsoleCommandArgument
 from sims4communitylib.services.commands.common_console_command_output import CommonConsoleCommandOutput
+from sims4communitylib.utils.common_omega_utils import CommonOmegaUtils
 from sims4communitylib.utils.common_type_utils import CommonTypeUtils
 from sims4communitylib.utils.sims.common_sim_utils import CommonSimUtils
 
@@ -103,6 +105,72 @@ class CommonCameraUtils:
         """
         from camera import cancel_focus
         cancel_focus(object=game_object)
+
+    @classmethod
+    def local_start_focus_on_sim(cls, sim_info: SimInfo, follow: bool = True, client: Client = None):
+        """local_start_focus_on_sim(sim_info)
+
+        Focus the player camera on a Sim using local messaging for compatibility with S4MP.
+
+        :param sim_info: The SimInfo of the Sim to focus the camera on.
+        :type sim_info: SimInfo
+        :param follow: If True, the camera will follow the object after focusing on it. If False, the camera will not follow the object after focusing on it. Default is True.
+        :type follow: bool, optional
+        :param client: The client to focus on the Sim. If None, the active client will be used. Default is None.
+        :type client: Client, optional
+        """
+
+        camera_focus_op = FocusCamera(id=sim_info.id, follow_mode=follow)
+
+        CommonOmegaUtils.send_view_update_message(camera_focus_op, client=client)
+
+    @classmethod
+    def local_start_focus_on_position(cls, position: CommonVector3, client: Client = None):
+        """local_start_focus_on_position(position)
+
+        Focus the player camera on a position using local messaging for compatibility with S4MP.
+
+        :param position: The position to focus the camera on.
+        :type position: CommonVector3
+        :param client: The client to focus on the position. If None, the active client will be used. Default is None.
+        :type client: Client, optional
+        """
+
+        camera_focus_op = FocusCamera()
+        camera_focus_op.set_position(position)
+
+        CommonOmegaUtils.send_view_update_message(camera_focus_op, client=client)
+
+    @classmethod
+    def local_start_focus_on_object(cls, game_object: GameObject, follow: bool = True, client: Client = None):
+        """local_start_focus_on_object(game_object)
+
+        Focus the player camera on a game object using local messaging for compatibility with S4MP.
+
+        :param game_object: The object to focus on.
+        :type game_object: GameObject
+        :param follow: If True, the camera will follow the object after focusing on it. If False, the camera will not follow the object after focusing on it. Default is True.
+        :type follow: bool, optional
+        :param client: The client to focus on the Sim. If None, the active client will be used. Default is None.
+        :type client: Client, optional
+        """
+
+        camera_focus_op = FocusCamera(id=game_object.id, follow_mode=follow)
+
+        CommonOmegaUtils.send_view_update_message(camera_focus_op, client=client)
+
+    @classmethod
+    def local_stop_focus_on_object(cls, game_object: GameObject):
+        """local_stop_focus_on_object(game_object)
+
+        Stop focusing the player camera on a game object.
+
+        :param game_object: The object to stop focusing on.
+        :type game_object: GameObject
+        """
+        camera_stop_focus_op = CancelFocusCamera(id=game_object.id)
+
+        CommonOmegaUtils.send_view_update_message(camera_stop_focus_op)
 
 
 @CommonConsoleCommand(


### PR DESCRIPTION
This PR adds methods that send operations to the game client directly via the omega (?) module instead of using Client and Distributor instances. What this means, for users, is that when using S4MP (or possibly any other Sims 4 Multiplayer Mod) they can generate a camera-related event that only occurs on the instance where the command was executed and isn't distributed to the other players, as happens with the regular camera methods.